### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Kagura
 
-Frontend frame-work for wasm on Rust.
+A front-end framework that runs on WebAssembly written in Rust.
 
 </div>
 


### PR DESCRIPTION
If I understand correctly, the term "front-end" here is a compound adjective in this sentence, and "framework" is a single word. and the term "front-end" should be hyphenated when used as a compound adjective.